### PR TITLE
Fixing the malformed and client protocol issue

### DIFF
--- a/src/codec.zig
+++ b/src/codec.zig
@@ -216,11 +216,12 @@ pub fn encodeUnsubscribe(buf: []u8, packet_identifier: u16, opts: mqttz.Unsubscr
 }
 
 pub fn encodePublish(buf: []u8, packet_identifier: ?u16, opts: mqttz.PublishOpts) ![]u8 {
-    var publish_flags = PublishFlags{
+    const publish_flags = PublishFlags{
         .dup = opts.dup,
         .qos = opts.qos,
         .retain = opts.retain,
     };
+    _ = publish_flags;
 
     // reserve 1 byte for the packet type
     // reserve 4 bytes for the packet length (which might be less than 4 bytes)
@@ -243,7 +244,7 @@ pub fn encodePublish(buf: []u8, packet_identifier: ?u16, opts: mqttz.PublishOpts
         return error.WriteBufferIsFull;
     }
     @memcpy(buf[payload_offset..end], message);
-    return encodePacketHeader(buf[0..end], 3, @as([*]u4, @ptrCast(@alignCast(&publish_flags)))[0]);
+    return encodePacketHeader(buf[0..end], 3, 0);
 }
 
 pub fn encodePubAck(buf: []u8, opts: mqttz.PubAckOpts) ![]u8 {


### PR DESCRIPTION
Issue: The publisher is getting disconnected when it tries to connect with the server. The server logs the complaint as a `protocol error.`

Root cause: The `publish_flags` setting in the `encodePublish` is returning different packet_flags (112) in place of the expected (48). The behavior can be verified with current test cases itself.

Solution: After debugging a bit, I found that the issue was with publish_flag pointer encoding, and it has been suppressed in the posix.publish method to mitigate this. Post the fix; both subscriber and publisher work as expected.

I am raising this PR to bring this to your attention to get this fix merged or mitigated properly.

Moreover @karlseguin Thanks for this wonderful effort and making this library available for us.

