### PR TITLE
Migration to Zig 0.16

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,36 +24,36 @@ pub fn build(b: *std.Build) !void {
         test_step.dependOn(&run_test.step);
     }
 
-    {
-        const exe = b.addExecutable(.{
-            .name = "mqttz_low_level_example_subscriber",
-            .root_module =  b.createModule(.{
-                .root_source_file = b.path("example/low_level/subscriber.zig"),
-                .target = target,
-                .optimize = optimize,
-            }),
-        });
-        exe.root_module.addImport("mqttz", mqttz_module);
-        setupExample(b, exe, "low_level_subscriber");
-    }
+    // {
+    //     const exe = b.addExecutable(.{
+    //         .name = "mqttz_low_level_example_subscriber",
+    //         .root_module =  b.createModule(.{
+    //             .root_source_file = b.path("example/low_level/subscriber.zig"),
+    //             .target = target,
+    //             .optimize = optimize,
+    //         }),
+    //     });
+    //     exe.root_module.addImport("mqttz", mqttz_module);
+    //     setupExample(b, exe, "low_level_subscriber");
+    // }
 
-    {
-        const exe = b.addExecutable(.{
-            .name = "mqttz_low_level_example_publisher",
-            .root_module =  b.createModule(.{
-                .root_source_file = b.path("example/low_level/publisher.zig"),
-                .target = target,
-                .optimize = optimize,
-            }),
-        });
-        exe.root_module.addImport("mqttz", mqttz_module);
-        setupExample(b, exe, "low_level_publisher");
-    }
+    // {
+    //     const exe = b.addExecutable(.{
+    //         .name = "mqttz_low_level_example_publisher",
+    //         .root_module =  b.createModule(.{
+    //             .root_source_file = b.path("example/low_level/publisher.zig"),
+    //             .target = target,
+    //             .optimize = optimize,
+    //         }),
+    //     });
+    //     exe.root_module.addImport("mqttz", mqttz_module);
+    //     setupExample(b, exe, "low_level_publisher");
+    // }
 
     {
         const exe = b.addExecutable(.{
             .name = "mqttz_posix_example_subscriber",
-            .root_module =  b.createModule(.{
+            .root_module = b.createModule(.{
                 .root_source_file = b.path("example/posix/subscriber.zig"),
                 .target = target,
                 .optimize = optimize,
@@ -66,7 +66,7 @@ pub fn build(b: *std.Build) !void {
     {
         const exe = b.addExecutable(.{
             .name = "mqttz_posix_example_publisher",
-            .root_module =  b.createModule(.{
+            .root_module = b.createModule(.{
                 .root_source_file = b.path("example/posix/publisher.zig"),
                 .target = target,
                 .optimize = optimize,

--- a/example/low_level/publisher.zig
+++ b/example/low_level/publisher.zig
@@ -11,7 +11,7 @@ const mqttz = @import("mqttz");
 
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
-    const host_name = try std.Io.net.HostName.init("test.mosquitto.org");
+    const host_name = try std.Io.net.HostName.init("127.0.0.1");
 
     const stream = try host_name.connect(io, 1883, .{ .mode = .stream, .protocol = .tcp });
     // will get closed when client.disconnect() is closed

--- a/example/low_level/publisher.zig
+++ b/example/low_level/publisher.zig
@@ -9,129 +9,116 @@ const mqttz = @import("mqttz");
 // more complicated: after publishing we'd need to get a pubrel/pubrec and deal
 // with potential timeouts and such.
 
-pub fn main() !void {
-	const address = blk: {
-		// mqttz is allocation-free. But your wrapper doesn't have to be. For example
-		// here we need an allocator to resolve the address.
-		var buf: [2048]u8 = undefined;
-		var fba = std.heap.FixedBufferAllocator.init(&buf);
-		const list = try std.net.getAddressList(fba.allocator(), "test.mosquitto.org", 1883);
-		defer list.deinit();
-		if (list.addrs.len == 0) return error.UnknownHostName;
-		break :blk list.addrs[0];
-	};
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const host_name = try std.Io.net.HostName.init("test.mosquitto.org");
 
-	const stream = try std.net.tcpConnectToAddress(address);
-	// will get closed when client.disconnect() is called
+    const stream = try host_name.connect(io, 1883, .{ .mode = .stream, .protocol = .tcp });
+    // will get closed when client.disconnect() is closed
 
-	// we never read very large messages
-	var read_buf: [256]u8 = undefined;
-	// this has to be at least big enough to hold our largest message + the topic
-	// name + a few bytes of overhead
-	var write_buf: [1024]u8 = undefined;
+    // we never read very large messages
+    var read_buf: [256]u8 = undefined;
+    // this has to be at least big enough to hold our largest message + the topic
+    // name + a few bytes of overhead
+    var write_buf: [1024]u8 = undefined;
 
-	var client = Client{
-		.socket = stream.handle,
-		.mqtt = mqttz.Mqtt5(Client).init(&read_buf, &write_buf),
-	};
-	defer client.disconnect(.normal);
+    var client = Client{
+        .socket = stream.handle,
+        .mqtt = mqttz.Mqtt5(Client).init(&read_buf, &write_buf),
+    };
+    defer client.disconnect(.normal);
 
-	// in our connect, we call readPacket and return the mqttz.Packet.Connack
-	// this packet might have useful information about the server's capabilities.
-	_ = try client.connect(.{
-		.user_properties = &.{
-			.{.key = "client", .value = "mqttz"},
-			.{.key = "example", .value = "publisher"},
-		}
-	});
+    // in our connect, we call readPacket and return the mqttz.Packet.Connack
+    // this packet might have useful information about the server's capabilities.
+    _ = try client.connect(.{ .user_properties = &.{
+        .{ .key = "client", .value = "mqttz" },
+        .{ .key = "example", .value = "publisher" },
+    } });
 
-	var buf: [50]u8 = undefined;
-	for (9000..9003) |i| {
-		try client.publish("power/goku", try std.fmt.bufPrint(&buf, "over {d}!", .{i}));
-		std.Thread.sleep(std.time.ns_per_s);
-	}
+    var buf: [50]u8 = undefined;
+    for (9000..9003) |i| {
+        try client.publish("power/goku", try std.fmt.bufPrint(&buf, "over {d}!", .{i}));
+        std.Thread.sleep(std.time.ns_per_s);
+    }
 }
 
 // In this example, we use composition. The Client wraps the `Mqtt(T)`.
 const Client = struct {
-	socket: std.posix.socket_t,
-	mqtt: mqttz.Mqtt5(Client),
+    socket: std.posix.socket_t,
+    mqtt: mqttz.Mqtt5(Client),
 
-	// wrap mqtt methods, largely so we can inject the state
-	// which, in this case (and in most) is going to be the Client itself.
-	fn connect(self: *Client, opts: mqttz.ConnectOpts) !mqttz.Packet.ConnAck {
-		try self.mqtt.connect(self, opts);
+    // wrap mqtt methods, largely so we can inject the state
+    // which, in this case (and in most) is going to be the Client itself.
+    fn connect(self: *Client, opts: mqttz.ConnectOpts) !mqttz.Packet.ConnAck {
+        try self.mqtt.connect(self, opts);
 
-		// since this simple demo doesn't implement a timeout, readPacket should
-		// either fail or returna a packet.
-		const packet = (try self.readPacket()) orelse unreachable;
+        // since this simple demo doesn't implement a timeout, readPacket should
+        // either fail or returna a packet.
+        const packet = (try self.readPacket()) orelse unreachable;
 
-		// after we send a connect, the only valid packets we can get back are
-		// connack and disconnect and disconnect is handled by our readPacket
-		switch (packet) {
-			.connack => |c| {
-				if (c.reason_code == .success) {
-					return c;
-				}
-				std.debug.print("failed to connect: {any}\n", .{c.reason_code});
-				return error.ConnectionFailed;
-			},
-			else => {
-				std.debug.print("unexpected packet: {any}\n", .{self.mqtt.lastReadPacket()});
-				return error.UnexpectPacket;
-			},
-		}
-	}
+        // after we send a connect, the only valid packets we can get back are
+        // connack and disconnect and disconnect is handled by our readPacket
+        switch (packet) {
+            .connack => |c| {
+                if (c.reason_code == .success) {
+                    return c;
+                }
+                std.debug.print("failed to connect: {any}\n", .{c.reason_code});
+                return error.ConnectionFailed;
+            },
+            else => {
+                std.debug.print("unexpected packet: {any}\n", .{self.mqtt.lastReadPacket()});
+                return error.UnexpectPacket;
+            },
+        }
+    }
 
-	fn disconnect(self: *Client, reason: mqttz.ClientDisconnectReason) void {
-		self.mqtt.disconnect(self, .{
-			.reason = reason
-		}) catch {};
-	}
+    fn disconnect(self: *Client, reason: mqttz.ClientDisconnectReason) void {
+        self.mqtt.disconnect(self, .{ .reason = reason }) catch {};
+    }
 
-	pub fn publish(self: *Client, topic: []const u8, message: []const u8) !void {
-		// because we're using the default QoS, QoS.at_most_once, we won't need
-		// to receive a pubrel/pubrec. So we don't care about the returned packet_identifier.
-		// This is fire-and-forget.
-		_ = try self.mqtt.publish(self, .{
-			.topic = topic,
-			.message = message,
-			.qos = .at_most_once, // this is the default, but let's be explicit
-		});
-	}
+    pub fn publish(self: *Client, topic: []const u8, message: []const u8) !void {
+        // because we're using the default QoS, QoS.at_most_once, we won't need
+        // to receive a pubrel/pubrec. So we don't care about the returned packet_identifier.
+        // This is fire-and-forget.
+        _ = try self.mqtt.publish(self, .{
+            .topic = topic,
+            .message = message,
+            .qos = .at_most_once, // this is the default, but let's be explicit
+        });
+    }
 
-	// nice thing about composition is that it's easy to apply global handling
-	// for various packet types.
-	fn readPacket(self: *Client) !?mqttz.Packet {
-		if (try self.mqtt.readPacket(self)) |packet| switch (packet) {
-			.disconnect => |d| {
-				std.debug.print("server disconnected: {any}\n", .{d.reason_code});
-				return error.Disconnected;
-			},
-			else => return packet,
-		};
-		return null;
-	}
+    // nice thing about composition is that it's easy to apply global handling
+    // for various packet types.
+    fn readPacket(self: *Client) !?mqttz.Packet {
+        if (try self.mqtt.readPacket(self)) |packet| switch (packet) {
+            .disconnect => |d| {
+                std.debug.print("server disconnected: {any}\n", .{d.reason_code});
+                return error.Disconnected;
+            },
+            else => return packet,
+        };
+        return null;
+    }
 
-	pub const MqttPlatform = struct {
-		// We must provide a read function
-		pub fn read(self: *Client, buf: []u8, _: usize) !?usize {
-			return try std.posix.read(self.socket, buf);
-		}
+    pub const MqttPlatform = struct {
+        // We must provide a read function
+        pub fn read(self: *Client, buf: []u8, _: usize) !?usize {
+            return try std.posix.read(self.socket, buf);
+        }
 
-		// We must provide a write function
-		pub fn write(self: *Client, data: []const u8) !void {
-			var pos: usize = 0;
-			const socket = self.socket;
-			while (pos < data.len) {
-				pos += try std.posix.write(socket, data[pos..]);
-			}
-		}
+        // We must provide a write function
+        pub fn write(self: *Client, data: []const u8) !void {
+            var pos: usize = 0;
+            const socket = self.socket;
+            while (pos < data.len) {
+                pos += try std.posix.write(socket, data[pos..]);
+            }
+        }
 
-		// We must provide a close function
-		pub fn close(self: *Client) void {
-			std.posix.close(self.socket);
-		}
-	};
+        // We must provide a close function
+        pub fn close(self: *Client) void {
+            std.posix.close(self.socket);
+        }
+    };
 };
-

--- a/example/low_level/subscriber.zig
+++ b/example/low_level/subscriber.zig
@@ -7,178 +7,164 @@ const mqttz = @import("mqttz");
 // This is an example of of client that subscribes to a topic and then
 // receives message. This is a simple, but common example. It's simple because
 // we mostly know what type of packets to expect when we call readPacket.
-pub fn main() !void {
-	const address = blk: {
-		// mqttz is allocation-free. But your wrapper doesn't have to be. For example
-		// here we need an allocator to resolve the address.
-		var buf: [2048]u8 = undefined;
-		var fba = std.heap.FixedBufferAllocator.init(&buf);
-		const list = try std.net.getAddressList(fba.allocator(), "test.mosquitto.org", 1883);
-		defer list.deinit();
-		if (list.addrs.len == 0) return error.UnknownHostName;
-		break :blk list.addrs[0];
-	};
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const host_name = try std.Io.net.HostName.init("test.mosquitto.org");
 
-	const stream = try std.net.tcpConnectToAddress(address);
-	// will get closed when client.disconnect() is closed
+    const stream = try host_name.connect(io, 1883, .{ .mode = .stream, .protocol = .tcp });
+    // will get closed when client.disconnect() is closed
 
-	var read_buf: [4096]u8 = undefined;
+    var read_buf: [4096]u8 = undefined;
 
-	// we never write very big messages. The longest part of our message is
-	// the topic name that we subscribe to (plus a few bytes of overhead in the
-	// packet structure)
-	var write_buf: [256]u8 = undefined;
+    // we never write very big messages. The longest part of our message is
+    // the topic name that we subscribe to (plus a few bytes of overhead in the
+    // packet structure)
+    var write_buf: [256]u8 = undefined;
 
-	var client = Client{
-		.socket = stream.handle,
-		.mqtt = mqttz.Mqtt5(Client).init(&read_buf, &write_buf),
-	};
-	defer client.disconnect(.normal);
+    var client = Client{
+        .socket = stream.handle,
+        .mqtt = mqttz.Mqtt5(Client).init(&read_buf, &write_buf),
+    };
+    defer client.disconnect(.normal);
 
-	// in our connect, we call readPacket and return the mqttz.Packet.Connack
-	// this packet might have useful information about the server's capabilities.
-	_ = try client.connect(.{
-		.maximum_packet_size = 4096,
-		.user_properties = &.{
-			.{.key = "client", .value = "mqttz"},
-			.{.key = "example", .value = "subscriber"},
-		}
-	});
+    // in our connect, we call readPacket and return the mqttz.Packet.Connack
+    // this packet might have useful information about the server's capabilities.
+    _ = try client.connect(.{ .maximum_packet_size = 4096, .user_properties = &.{
+        .{ .key = "client", .value = "mqttz" },
+        .{ .key = "example", .value = "subscriber" },
+    } });
 
-	try client.subscribe("power/goku");
+    try client.subscribe("power/goku");
 
-	// since we're using a public test server, we won't keep this open longer
-	// than necessary
-	for (0..3) |_| {
-		if (try client.readPacket()) |packet| switch (packet) {
-			.publish => |*publish| client.handleMessage(publish),
-			else => {
-				// always have to be mindful of the bi-directional nature of MQTT
-				// but in this case, nothing here should be possible.
-				// client.readPacket handles `disconnect` and our above connect and
-				// subscribe should have handled their corresponing connack and suback
-				std.debug.print("unexpected packet: {any}\n", .{packet});
-			}
-		};
-	}
+    // since we're using a public test server, we won't keep this open longer
+    // than necessary
+    for (0..3) |_| {
+        if (try client.readPacket()) |packet| switch (packet) {
+            .publish => |*publish| client.handleMessage(publish),
+            else => {
+                // always have to be mindful of the bi-directional nature of MQTT
+                // but in this case, nothing here should be possible.
+                // client.readPacket handles `disconnect` and our above connect and
+                // subscribe should have handled their corresponing connack and suback
+                std.debug.print("unexpected packet: {any}\n", .{packet});
+            },
+        };
+    }
 }
 
 // In this example, we use composition. The Client wraps the `Mqtt(T)`.
 const Client = struct {
-	socket: std.posix.socket_t,
-	mqtt: mqttz.Mqtt5(Client),
+    socket: std.posix.socket_t,
+    mqtt: mqttz.Mqtt5(Client),
 
-	// wrap mqtt methods, largely so we can inject the state
-	// which, in this case (and in most) is going to be the Client itself.
-	fn connect(self: *Client, opts: mqttz.ConnectOpts) !mqttz.Packet.ConnAck {
-		try self.mqtt.connect(self, opts);
+    // wrap mqtt methods, largely so we can inject the state
+    // which, in this case (and in most) is going to be the Client itself.
+    fn connect(self: *Client, opts: mqttz.ConnectOpts) !mqttz.Packet.ConnAck {
+        try self.mqtt.connect(self, opts);
 
-		// since this simple demo doesn't implement a timeout, readPacket should
-		// either fail or returna a packet.
-		const packet = (try self.readPacket()) orelse unreachable;
+        // since this simple demo doesn't implement a timeout, readPacket should
+        // either fail or returna a packet.
+        const packet = (try self.readPacket()) orelse unreachable;
 
-		// after we send a connect, the only valid packets we can get back are
-		// connack and disconnect and disconnect is handled by our readPacket
-		switch (packet) {
-			.connack => |c| {
-				if (c.reason_code == .success) {
-					return c;
-				}
-				std.debug.print("failed to connect: {any}\n", .{c.reason_code});
-				return error.ConnectionFailed;
-			},
-			else => {
-				std.debug.print("unexpected packet: {any}\n", .{self.mqtt.lastReadPacket()});
-				return error.UnexpectPacket;
-			},
-		}
-	}
+        // after we send a connect, the only valid packets we can get back are
+        // connack and disconnect and disconnect is handled by our readPacket
+        switch (packet) {
+            .connack => |c| {
+                if (c.reason_code == .success) {
+                    return c;
+                }
+                std.debug.print("failed to connect: {any}\n", .{c.reason_code});
+                return error.ConnectionFailed;
+            },
+            else => {
+                std.debug.print("unexpected packet: {any}\n", .{self.mqtt.lastReadPacket()});
+                return error.UnexpectPacket;
+            },
+        }
+    }
 
-	fn disconnect(self: *Client, reason: mqttz.ClientDisconnectReason) void {
-		self.mqtt.disconnect(self, .{
-			.reason = reason
-		}) catch {};
-	}
+    fn disconnect(self: *Client, reason: mqttz.ClientDisconnectReason) void {
+        self.mqtt.disconnect(self, .{ .reason = reason }) catch {};
+    }
 
-	fn subscribe(self: *Client, topic: []const u8) !void {
-		const packet_identifier = try self.mqtt.subscribe(self, .{
-			.topics = &.{
-				.{.filter = topic, .qos = .at_most_once},
-			},
-		});
+    fn subscribe(self: *Client, topic: []const u8) !void {
+        const packet_identifier = try self.mqtt.subscribe(self, .{
+            .topics = &.{
+                .{ .filter = topic, .qos = .at_most_once },
+            },
+        });
 
-		// what's up with this while loop? Well, If we call subscribe multiple times
-		// it's possible that calls to readPacket will start getting published messages
-		// so we need to loop until we get our suback, processing any publish packets
-		//
-		// If you need to subscribe to multiple topics, it's MUCH better to do so
-		// in a single call to subscribe. Then you avoid this issue.
-		// However, if the subscriptions are dynamic, then you might need to take
-		// this approach
+        // what's up with this while loop? Well, If we call subscribe multiple times
+        // it's possible that calls to readPacket will start getting published messages
+        // so we need to loop until we get our suback, processing any publish packets
+        //
+        // If you need to subscribe to multiple topics, it's MUCH better to do so
+        // in a single call to subscribe. Then you avoid this issue.
+        // However, if the subscriptions are dynamic, then you might need to take
+        // this approach
 
-		while (true) {
-			if (try self.readPacket()) |packet| switch (packet) {
-				.publish => |*publish| self.handleMessage(publish),
-				.suback => |suback| {
-					if (suback.packet_identifier != packet_identifier) {
-						return error.WrongPacketIdentifier;
-					}
+        while (true) {
+            if (try self.readPacket()) |packet| switch (packet) {
+                .publish => |*publish| self.handleMessage(publish),
+                .suback => |suback| {
+                    if (suback.packet_identifier != packet_identifier) {
+                        return error.WrongPacketIdentifier;
+                    }
 
-					// our implementation asked for at_most_once
-					// it should have gotten a suback with at_most_once
-					// we can't handle anything more (in this implementation)
-					if (try suback.result(0) != .at_most_once) {
-						return error.UnexpectedQOS;
-					}
-					return;
-				},
-				else => {
-					std.debug.print("unexpected packet: {any}\n", .{self.mqtt.lastReadPacket()});
-					return error.UnexpectPacket;
-				},
-			};
-		}
-	}
+                    // our implementation asked for at_most_once
+                    // it should have gotten a suback with at_most_once
+                    // we can't handle anything more (in this implementation)
+                    if (try suback.result(0) != .at_most_once) {
+                        return error.UnexpectedQOS;
+                    }
+                    return;
+                },
+                else => {
+                    std.debug.print("unexpected packet: {any}\n", .{self.mqtt.lastReadPacket()});
+                    return error.UnexpectPacket;
+                },
+            };
+        }
+    }
 
-	fn handleMessage(_: *Client, publish: *const mqttz.Packet.Publish) void {
-		// if publish.qos is .at_least_once or .exactly_once, then we'll need to
-		// send purec/pubrel
-		std.debug.print("received\ntopic: {s}\n{s}\n\n", .{publish.topic, publish.message});
-	}
+    fn handleMessage(_: *Client, publish: *const mqttz.Packet.Publish) void {
+        // if publish.qos is .at_least_once or .exactly_once, then we'll need to
+        // send purec/pubrel
+        std.debug.print("received\ntopic: {s}\n{s}\n\n", .{ publish.topic, publish.message });
+    }
 
-	// nice thing about composition is that it's easy to apply global handling
-	// for various packet types.
-	fn readPacket(self: *Client) !?mqttz.Packet {
-		if (try self.mqtt.readPacket(self)) |packet| switch (packet) {
-			.disconnect => |d| {
-				std.debug.print("server disconnected: {any}\n", .{d.reason_code});
-				return error.Disconnected;
-			},
-			else => return packet,
-		};
+    // nice thing about composition is that it's easy to apply global handling
+    // for various packet types.
+    fn readPacket(self: *Client) !?mqttz.Packet {
+        if (try self.mqtt.readPacket(self)) |packet| switch (packet) {
+            .disconnect => |d| {
+                std.debug.print("server disconnected: {any}\n", .{d.reason_code});
+                return error.Disconnected;
+            },
+            else => return packet,
+        };
 
-		return null;
-	}
+        return null;
+    }
 
-	pub const MqttPlatform = struct {
-		// We must provide a read function
-		pub fn read(self: *Client, buf: []u8, _: usize) !?usize {
-			return try std.posix.read(self.socket, buf);
-		}
+    pub const MqttPlatform = struct {
+        // We must provide a read function
+        pub fn read(self: *Client, buf: []u8, _: usize) !?usize {
+            return try std.posix.read(self.socket, buf);
+        }
 
-		// We must provide a write function
-		pub fn write(self: *Client, data: []const u8) !void {
-			var pos: usize = 0;
-			const socket = self.socket;
-			while (pos < data.len) {
-				pos += try std.posix.write(socket, data[pos..]);
-			}
-		}
+        // We must provide a write function
+        pub fn write(self: *Client, data: []const u8) !void {
+            var pos: usize = 0;
+            const socket = self.socket;
+            while (pos < data.len) {
+                pos += try std.posix.write(socket, data[pos..]);
+            }
+        }
 
-		// We must provide a close function
-		pub fn close(self: *Client) void {
-			std.posix.close(self.socket);
-		}
-	};
+        // We must provide a close function
+        pub fn close(self: *Client) void {
+            std.posix.close(self.socket);
+        }
+    };
 };
-

--- a/example/low_level/subscriber.zig
+++ b/example/low_level/subscriber.zig
@@ -9,7 +9,7 @@ const mqttz = @import("mqttz");
 // we mostly know what type of packets to expect when we call readPacket.
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
-    const host_name = try std.Io.net.HostName.init("test.mosquitto.org");
+    const host_name = try std.Io.net.HostName.init("127.0.0.1");
 
     const stream = try host_name.connect(io, 1883, .{ .mode = .stream, .protocol = .tcp });
     // will get closed when client.disconnect() is closed

--- a/example/posix/publisher.zig
+++ b/example/posix/publisher.zig
@@ -6,52 +6,45 @@ const mqttz = @import("mqttz");
 // mqttz.QoS.at_most_once. If we used a higher level, then things would get
 // more complicated: after publishing we'd need to get a pubrel/pubrec and deal
 // with potential timeouts and such.
-pub fn main() !void {
-	var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-	const allocator = gpa.allocator();
-	defer _ = gpa.detectLeaks();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
-	var client = try mqttz.posix.Client5.init(.{
-		.port = 1883,
-		.host = "test.mosquitto.org",
-		// It IS possible to use the posix client without an allocator, see readme
-		.allocator = allocator,
-	});
+    var client = try mqttz.posix.Client5.init(init.io, .{
+        .port = 1883,
+        .host = "test.mosquitto.org",
+        // It IS possible to use the posix client without an allocator, see readme
+        .allocator = allocator,
+    });
 
-	defer {
-		client.disconnect(.{.timeout = 1000}, .{.reason = .normal}) catch {};
-		client.deinit();
-	}
+    defer {
+        client.disconnect(.{ .timeout = 1000 }, .{ .reason = .normal }) catch {};
+        client.deinit();
+    }
 
-	_ = try client.connect(.{.timeout = 2000}, .{
-		.user_properties = &.{
-			.{.key = "client", .value = "mqttz"},
-			.{.key = "example", .value = "publisher"},
-		}
-	});
+    _ = try client.connect(.{ .timeout = 2000 }, .{ .user_properties = &.{
+        .{ .key = "client", .value = "mqttz" },
+        .{ .key = "example", .value = "publisher" },
+    } });
 
-	if (try client.readPacket(.{})) |packet| switch (packet) {
-		.disconnect => |d| {
-			std.debug.print("server disconnected us: {s}", .{@tagName(d.reason_code)});
-			return;
-		},
-		.connack => {
-			// TODO: the connack packet can include server capabilities. We might care
-			// about these to tweak how our client behaves (like, what is the maximum
-			// supported QoS)
-		},
-		else => {
-			// The server should not send any other type of packet at this point
-			// HOWEVER, we should probably handle this case better than an `unreachable`
-		}
-	};
+    if (try client.readPacket(.{})) |packet| switch (packet) {
+        .disconnect => |d| {
+            std.debug.print("server disconnected us: {s}", .{@tagName(d.reason_code)});
+            return;
+        },
+        .connack => {
+            // TODO: the connack packet can include server capabilities. We might care
+            // about these to tweak how our client behaves (like, what is the maximum
+            // supported QoS)
+        },
+        else => {
+            // The server should not send any other type of packet at this point
+            // HOWEVER, we should probably handle this case better than an `unreachable`
+        },
+    };
 
-	var buf: [50]u8 = undefined;
-	for (5000..5003) |i| {
-		_ = try client.publish(.{}, .{
-			.topic = "power/vegeta",
-			.message = try std.fmt.bufPrint(&buf, "over {d}!", .{i})
-		});
-		std.Thread.sleep(std.time.ns_per_s);
-	}
+    var buf: [50]u8 = undefined;
+    for (5000..5003) |i| {
+        _ = try client.publish(.{}, .{ .topic = "power/vegeta", .message = try std.fmt.bufPrint(&buf, "over {d}!", .{i}) });
+        try std.Io.sleep(init.io, .fromSeconds(1), .awake);
+    }
 }

--- a/example/posix/publisher.zig
+++ b/example/posix/publisher.zig
@@ -11,7 +11,7 @@ pub fn main(init: std.process.Init) !void {
 
     var client = try mqttz.posix.Client5.init(init.io, .{
         .port = 1883,
-        .host = "localhost",
+        .ip = "127.0.0.1",
         // It IS possible to use the posix client without an allocator, see readme
         .allocator = allocator,
     });

--- a/example/posix/publisher.zig
+++ b/example/posix/publisher.zig
@@ -11,7 +11,7 @@ pub fn main(init: std.process.Init) !void {
 
     var client = try mqttz.posix.Client5.init(init.io, .{
         .port = 1883,
-        .host = "test.mosquitto.org",
+        .host = "localhost",
         // It IS possible to use the posix client without an allocator, see readme
         .allocator = allocator,
     });

--- a/example/posix/subscriber.zig
+++ b/example/posix/subscriber.zig
@@ -4,90 +4,84 @@ const mqttz = @import("mqttz");
 // This is an example of of client that subscribes to a topic and then
 // receives message. This is a simple, but common example. It's simple because
 // we mostly know what type of packets to expect when we call readPacket.
-pub fn main() !void {
-	var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-	const allocator = gpa.allocator();
-	defer _ = gpa.detectLeaks();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
-	var client = try mqttz.posix.Client5.init(.{
-		.port = 1883,
-		.host = "test.mosquitto.org",
-		// It IS possible to use the posix client without an allocator, see readme
-		.allocator = allocator,
-	});
+    var client = try mqttz.posix.Client5.init(init.io, .{
+        .port = 1883,
+        .host = "test.mosquitto.org",
+        // It IS possible to use the posix client without an allocator, see readme
+        .allocator = allocator,
+    });
 
-	defer {
-		client.disconnect(.{.timeout = 1000}, .{.reason = .normal}) catch {};
-		client.deinit();
-	}
+    defer {
+        client.disconnect(.{ .timeout = 1000 }, .{ .reason = .normal }) catch {};
+        client.deinit();
+    }
 
-	_ = try client.connect(.{.timeout = 5000}, .{
-		.user_properties = &.{
-			.{.key = "client", .value = "mqttz"},
-			.{.key = "example", .value = "subscriber"},
-		}
-	});
+    _ = try client.connect(.{ .timeout = 5000 }, .{ .user_properties = &.{
+        .{ .key = "client", .value = "mqttz" },
+        .{ .key = "example", .value = "subscriber" },
+    } });
 
-	if (try client.readPacket(.{})) |packet| switch (packet) {
-		.disconnect => |d| {
-			std.debug.print("server disconnected us: {s}", .{@tagName(d.reason_code)});
-			return;
-		},
-		.connack => {
-			// TODO: the connack packet can include server capabilities. We might care
-			// about these to tweak how our client behaves (like, what is the maximum
-			// supported QoS)
-		},
-		else => {
-			// The server should not send any other type of packet at this point
-			// HOWEVER, we should probably handle this case better than an `unreachable`
-		}
-	};
+    if (try client.readPacket(.{})) |packet| switch (packet) {
+        .disconnect => |d| {
+            std.debug.print("server disconnected us: {s}", .{@tagName(d.reason_code)});
+            return;
+        },
+        .connack => {
+            // TODO: the connack packet can include server capabilities. We might care
+            // about these to tweak how our client behaves (like, what is the maximum
+            // supported QoS)
+        },
+        else => {
+            // The server should not send any other type of packet at this point
+            // HOWEVER, we should probably handle this case better than an `unreachable`
+        },
+    };
 
-	{
-		const packet_identifier = try client.subscribe(.{}, .{
-			.topics = &.{.{.filter = "power/vegeta", .qos = .at_most_once}}
-		});
-		if (try client.readPacket(.{})) |packet| switch (packet) {
-			.disconnect => |d| {
-				std.debug.print("server disconnected us: {s}", .{@tagName(d.reason_code)});
-				return;
-			},
-			.suback => |s| {
-				std.debug.assert(s.packet_identifier == packet_identifier);
-			},
-			else => {
-				// The server should not send any other type of packet at this point
-				// HOWEVER, we should probably handle this case better than an `unreachable`
-				unreachable;
-			}
-		};
-	}
+    {
+        const packet_identifier = try client.subscribe(.{}, .{ .topics = &.{.{ .filter = "power/vegeta", .qos = .at_most_once }} });
+        if (try client.readPacket(.{})) |packet| switch (packet) {
+            .disconnect => |d| {
+                std.debug.print("server disconnected us: {s}", .{@tagName(d.reason_code)});
+                return;
+            },
+            .suback => |s| {
+                std.debug.assert(s.packet_identifier == packet_identifier);
+            },
+            else => {
+                // The server should not send any other type of packet at this point
+                // HOWEVER, we should probably handle this case better than an `unreachable`
+                unreachable;
+            },
+        };
+    }
 
-	// since we're using a public test server, we won't keep this open longer
-	// than necessary
-	var count: usize = 0;
-	loop: while (true) {
-		const packet = try client.readPacket(.{.timeout = 1000}) orelse {
-			std.debug.print("Still waiting for messages...\n", .{});
-			continue :loop;
-		};
-		switch (packet) {
-			.publish => |*publish| {
-				std.debug.print("received\ntopic: {s}\n{s}\n\n", .{publish.topic, publish.message});
-				count += 1;
-				if (count == 3) {
-					// our publisher only sends 3 mesages
-					return;
-				}
-			},
-			else => {
-				// always have to be mindful of the bi-directional nature of MQTT
-				// but in this case, nothing here should be possible.
-				// client.readPacket handles `disconnect` and our above connect and
-				// subscribe should have handled their corresponing connack and suback
-				std.debug.print("unexpected packet: {any}\n", .{packet});
-			}
-		}
-	}
+    // since we're using a public test server, we won't keep this open longer
+    // than necessary
+    var count: usize = 0;
+    loop: while (true) {
+        const packet = try client.readPacket(.{ .timeout = 1000 }) orelse {
+            std.debug.print("Still waiting for messages...\n", .{});
+            continue :loop;
+        };
+        switch (packet) {
+            .publish => |*publish| {
+                std.debug.print("received\ntopic: {s}\n{s}\n\n", .{ publish.topic, publish.message });
+                count += 1;
+                if (count == 3) {
+                    // our publisher only sends 3 mesages
+                    return;
+                }
+            },
+            else => {
+                // always have to be mindful of the bi-directional nature of MQTT
+                // but in this case, nothing here should be possible.
+                // client.readPacket handles `disconnect` and our above connect and
+                // subscribe should have handled their corresponing connack and suback
+                std.debug.print("unexpected packet: {any}\n", .{packet});
+            },
+        }
+    }
 }

--- a/example/posix/subscriber.zig
+++ b/example/posix/subscriber.zig
@@ -9,7 +9,7 @@ pub fn main(init: std.process.Init) !void {
 
     var client = try mqttz.posix.Client5.init(init.io, .{
         .port = 1883,
-        .host = "localhost",
+        .ip = "127.0.0.1",
         // It IS possible to use the posix client without an allocator, see readme
         .allocator = allocator,
     });

--- a/example/posix/subscriber.zig
+++ b/example/posix/subscriber.zig
@@ -9,7 +9,7 @@ pub fn main(init: std.process.Init) !void {
 
     var client = try mqttz.posix.Client5.init(init.io, .{
         .port = 1883,
-        .host = "test.mosquitto.org",
+        .host = "localhost",
         // It IS possible to use the posix client without an allocator, see readme
         .allocator = allocator,
     });

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,8 @@
 This is a embedding-friendly MQTT client library for Zig. The library has two client: a platform-agnostic low level MQTT client where you bring your own read/write/close function and a higher level client based on Zig's stdlib.
 
 ## Examples
-These example connect to [test.mosquitto.org](https://test.mosquitto.org/), so please be respectful.
+  To run the posix clients, first start a local broker:
+  `docker run --rm -p 1883:1883 eclipse-mosquitto`
 
 The `example` folder contains examples of using both clients. The low-level client is implemented using Zig's standard library. This implementation is very basic and not as feature rich as `mqtt.posix.Client5` (i.e. no timeouts) . It is only included to show how to integrate the low-level client within your own platform.
 

--- a/src/mqtt.zig
+++ b/src/mqtt.zig
@@ -253,7 +253,6 @@ pub fn Mqtt311NoCheck(comptime T: type) type {
     return Mqtt(T, .{ .mqtt_3_1_1 = false });
 }
 
-
 pub fn Mqtt(comptime T: type, comptime protocol_version: ProtocolVersion) type {
     return struct {
         // buffer used for reading messages from the server. If a single message
@@ -402,7 +401,9 @@ pub fn Mqtt(comptime T: type, comptime protocol_version: ProtocolVersion) type {
             try self.writePacket(state, &.{ 192, 0 });
         }
 
-        pub fn disconnect(self: *Self, state: anytype, opts: DisconnectOpts) (WriteError || error{WriteBufferIsFull,})!void {
+        pub fn disconnect(self: *Self, state: anytype, opts: DisconnectOpts) (WriteError || error{
+            WriteBufferIsFull,
+        })!void {
             defer T.MqttPlatform.close(state);
             const disconnect_packet = try codec.encodeDisconnect(self.write_buf, protocol_version, opts);
             return self.writePacket(state, disconnect_packet);
@@ -1581,8 +1582,7 @@ test "Client: connect" {
             'e', '-',
             'c', 'l',
             'i', 'e',
-            'n',
-            't',
+            'n', 't',
 
             // WILL properties
             51, // will length

--- a/src/mqtt.zig
+++ b/src/mqtt.zig
@@ -1582,7 +1582,8 @@ test "Client: connect" {
             'e', '-',
             'c', 'l',
             'i', 'e',
-            'n', 't',
+            'n',
+            't',
 
             // WILL properties
             51, // will length

--- a/src/mqtt.zig
+++ b/src/mqtt.zig
@@ -2820,7 +2820,7 @@ const TestContext = struct {
     fn random(self: *TestContext) std.Random {
         if (self._random == null) {
             var seed: u64 = undefined;
-            std.posix.getrandom(std.mem.asBytes(&seed)) catch unreachable;
+            std.Io.random(t.io, std.mem.asBytes(&seed));
             self._random = std.Random.DefaultPrng.init(seed);
         }
         return self._random.?.random();

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -406,32 +406,27 @@ const Address = struct {
 const t = std.testing;
 
 test {
-    const address = try net.Address.parseIp("127.0.0.1", 6588);
-    const socket = try posix.socket(address.any.family, posix.SOCK.STREAM | posix.SOCK.CLOEXEC, posix.IPPROTO.TCP);
-    errdefer posix.close(socket);
-
-    try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
-    try posix.bind(socket, &address.any, address.getOsSockLen());
-    try posix.listen(socket, 2);
-    const thread = try std.Thread.spawn(.{}, TestServer.run, .{socket});
+    const addr = try net.IpAddress.parseIp4("127.0.0.1", 6588);
+    var serv = try addr.listen(t.io, .{ .reuse_address = true, .mode = .stream, .protocol = .tcp });
+    const thread = try std.Thread.spawn(.{}, TestServer.run, .{&serv});
     thread.detach();
 }
 
 test "Client: invalid config" {
-    try t.expectError(error.HostOrIPRequired, Client.init(.{ .port = 0, .allocator = t.allocator }));
+    try t.expectError(error.HostOrIPRequired, Client(.{ .mqtt_3_1_1 = true }).init(t.io, .{ .port = 0, .allocator = t.allocator }));
 
     // host specified
-    try t.expectError(error.AllocatorRequired, Client.init(.{ .port = 0, .host = "123", .read_buf = &[_]u8{}, .write_buf = &[_]u8{} }));
+    try t.expectError(error.AllocatorRequired, Client(.{ .mqtt_3_1_1 = true }).init(t.io, .{ .port = 0, .host = "123", .read_buf = &[_]u8{}, .write_buf = &[_]u8{} }));
 
     // no read_buf
-    try t.expectError(error.AllocatorRequired, Client.init(.{ .port = 0, .ip = "", .write_buf = &[_]u8{} }));
+    try t.expectError(error.AllocatorRequired, Client(.{ .mqtt_3_1_1 = true }).init(t.io, .{ .port = 0, .ip = "", .write_buf = &[_]u8{} }));
 
     // no write_buf
-    try t.expectError(error.AllocatorRequired, Client.init(.{ .port = 0, .ip = "", .read_buf = &[_]u8{} }));
+    try t.expectError(error.AllocatorRequired, Client(.{ .mqtt_3_1_1 = true }).init(t.io, .{ .port = 0, .ip = "", .read_buf = &[_]u8{} }));
 }
 
 test "Client: connect timeout" {
-    var client = try Client.init(.{
+    var client = try Client(.{ .mqtt_3_1_1 = true }).init(t.io, .{
         .port = 1883,
         .ip = "10.255.255.1", // unroutable
         .connect_timeout = 10,
@@ -440,10 +435,10 @@ test "Client: connect timeout" {
 
     defer client.deinit();
 
-    const start = std.time.milliTimestamp();
+    const start = std.Io.Timestamp.now(t.io, .awake).toMilliseconds();
     try t.expectError(error.Timeout, client.connect(.{}, .{}));
 
-    const elapsed = std.time.milliTimestamp() - start;
+    const elapsed = std.Io.Timestamp.now(t.io, .awake).toMilliseconds() - start;
     try t.expectEqual(true, elapsed >= 10 and elapsed < 15);
 }
 
@@ -469,7 +464,7 @@ test "Client: retry1 - no alloc" {
     // so long as the correct initialize arguments are included
 
     var buf: [128]u8 = undefined;
-    var client = try Client.init(.{
+    var client = try Client(.{ .mqtt_3_1_1 = true }).init(t.io, .{
         .port = 6588,
         .ip = "127.0.0.1",
         .read_buf = &buf, // should not be the same!
@@ -497,9 +492,9 @@ test "Client: read timeout" {
 
     _ = try client.publish(.{}, .{ .topic = "timeout", .message = "" });
 
-    const start = std.time.milliTimestamp();
+    const start = std.Io.Timestamp.now(t.io, .awake).toMilliseconds();
     try t.expectEqual(null, try client.readPacket(.{ .retries = 0, .timeout = 50 }));
-    const elapsed = std.time.milliTimestamp() - start;
+    const elapsed = std.Io.Timestamp.now(t.io, .awake).toMilliseconds() - start;
     try t.expectEqual(true, elapsed >= 50 and elapsed < 100);
 }
 
@@ -516,21 +511,16 @@ test "Client: read invalid response" {
 const TestServer = struct {
     // runs in a thread, but our TestServer itself is single threaded as, currently,
     // each test only needs 1 connection to the server at a time.
-    fn run(server: posix.socket_t) void {
+    fn run(server: *net.Server) !void {
         var state = State{};
 
         while (true) {
-            var address: std.net.Address = undefined;
-            var address_len: posix.socklen_t = @sizeOf(std.net.Address);
-            const socket = posix.accept(server, &address.any, &address_len, posix.SOCK.CLOEXEC) catch |err| {
-                std.debug.print("failed to accept socket: {}", .{err});
-                continue;
-            };
-            defer posix.close(socket);
+            const socket = try server.accept(t.io);
+            defer socket.close(t.io);
 
             var conn = TestConn{
                 .buf = undefined,
-                .socket = socket,
+                .socket = socket.socket.handle,
             };
             conn.handle(&state) catch |err| {
                 std.debug.print("TestConn handle: {}\n", .{err});
@@ -565,7 +555,7 @@ const TestConn = struct {
     fn handle(self: *TestConn, state: *TestServer.State) !void {
         if (std.mem.eql(u8, state.name, "retry1")) {
             state.name = "";
-            const reply = try codec.encodePublish(&self.buf, 0, .{ .topic = "retry1-ok", .message = "" });
+            const reply = try codec.encodePublish(&self.buf, .{ .mqtt_3_1_1 = true }, 0, .{ .topic = "retry1-ok", .message = "" });
             _ = try posix.write(self.socket, reply);
         } else if (std.mem.eql(u8, state.name, "retry2-a")) {
             // move the state forward, and close the connection to see if it'll retry again
@@ -573,7 +563,7 @@ const TestConn = struct {
             return;
         } else if (std.mem.eql(u8, state.name, "retry2-b")) {
             state.name = "";
-            const reply = try codec.encodePublish(&self.buf, 0, .{ .topic = "retry2-ok", .message = "" });
+            const reply = try codec.encodePublish(&self.buf, .{ .mqtt_3_1_1 = true }, 0, .{ .topic = "retry2-ok", .message = "" });
             _ = try posix.write(self.socket, reply);
         }
 
@@ -607,7 +597,7 @@ const TestConn = struct {
                     }
 
                     if (std.mem.eql(u8, p.topic, "timeout")) {
-                        std.Thread.sleep(std.time.ns_per_ms * 75);
+                        std.Io.sleep(t.io, .fromNanoseconds(std.time.ns_per_ms * 75), .awake) catch {};
                         continue;
                     }
 
@@ -646,7 +636,7 @@ const TestConn = struct {
             try self.readFill(missing);
             const b1 = buf[0];
             const data = buf[1 + length_of_len .. 1 + length_of_len + remaining_len];
-            return mqttz.Packet.decode(b1, data);
+            return mqttz.Packet.decode(b1, data, .{ .mqtt_3_1_1 = true });
         }
     }
 
@@ -668,7 +658,7 @@ const TestConn = struct {
 
 fn testClient(opts: anytype) Client(.mqtt_5_0) {
     _ = opts; // not currently used
-    return Client(.mqtt_5_0).init(.{
+    return Client(.mqtt_5_0).init(t.io, .{
         .port = 6588,
         .ip = "127.0.0.1",
         .allocator = t.allocator,

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -3,7 +3,7 @@ const mqttz = @import("mqtt.zig");
 const builtin = @import("builtin");
 
 const net = std.Io.net;
-const posix = std.posix;
+const posix = @import("posix_interface.zig");
 const Allocator = std.mem.Allocator;
 
 pub const Client5 = Client(.mqtt_5_0);
@@ -216,11 +216,10 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
                 timeout: i32 = 10_000,
             };
 
-            // Called by our composed mqtt.Client(T)
             pub fn read(ctx: *const Context, buf: []u8, _: usize) !?usize {
                 var client = ctx.client;
 
-                // const absolute_timeout = std.Io.Clock.now(.awake, client.io).toMilliseconds() + ctx.timeout;
+                const absolute_timeout = std.Io.Timestamp.now(client.io, .awake).toMilliseconds() + ctx.timeout;
 
                 // on disconnect, the number of times that we'll try to reconnect and
                 // continue. This counts downwards to 0.
@@ -229,38 +228,54 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
                 // If retries > 0 and we detect a disconnect, we'll attempt to reload the
                 // socket (hence socket is var, not const).
                 var socket = try client.getOrConnectSocket();
-                var reader_buf: [4096]u8 = undefined;
-                var socket_reader = socket.reader(client.io, &reader_buf);
-                var buf_writer = std.Io.Writer.fixed(buf);
-                loop: while (true) {
-                    const res = socket_reader.interface.stream(&buf_writer, .unlimited) catch |err| switch (socket_reader.err.?) {
-                        error.ConnectionResetByPeer => {
-                            socket = try handleError(client, &retries);
-                            continue :loop;
-                        },
-                        // error.Timeout => {
-                        //     const timeout: i32 = @intCast(absolute_timeout - std.Io.Clock.now(.awake, client.io).toMilliseconds());
-                        //     if (timeout < 0) {
-                        //         return null;
-                        //     }
-                        //     continue :loop;
-                        // },
-                        else => {
-                            std.debug.print("{any}\n", .{err});
-                            client.close();
-                            return err;
-                        },
-                    };
-                    try buf_writer.flush();
 
-                    if (res != 0) return res;
-                    continue :loop;
+                loop: while (true) {
+                    const n = posix.read(socket.socket.handle, buf) catch |err| {
+                        switch (err) {
+                            error.BrokenPipe, error.ConnectionResetByPeer => {
+                                socket = try handleError(client, &retries);
+                                continue :loop;
+                            },
+                            error.WouldBlock => {
+                                const timeout: i32 = @intCast(absolute_timeout - std.Io.Timestamp.now(client.io, .awake).toMilliseconds());
+                                if (timeout < 0) {
+                                    return null;
+                                }
+
+                                var fds = [1]posix.pollfd{.{ .fd = socket.socket.handle, .events = posix.POLL.IN, .revents = 0 }};
+                                if (try posix.poll(&fds, timeout) == 0) {
+                                    return null;
+                                }
+
+                                if (fds[0].revents & posix.POLL.IN != posix.POLL.IN) {
+                                    // handle any other non-POLLOUT event as an error
+                                    socket = try handleError(client, &retries);
+                                }
+
+                                // Either poll has told us we can read without blocking OR
+                                // poll told us there was a error, but retries > 0 and we managed
+                                // to reconnect. Either way, we're gonna try to read again.
+                                continue :loop;
+                            },
+                            else => {
+                                client.close();
+                                return err;
+                            },
+                        }
+                    };
+
+                    if (n != 0) {
+                        return n;
+                    }
+
+                    socket = try handleError(client, &retries);
                 }
             }
 
-            // Called by our composed mqtt.Client
             pub fn write(ctx: *const Context, data: []const u8) !void {
                 var client = ctx.client;
+
+                const absolute_timeout = std.Io.Timestamp.now(client.io, .awake).toMilliseconds() + ctx.timeout;
 
                 // on disconnect, the number of times that we'll try to reconnect and
                 // continue. This counts downwards to 0.
@@ -270,11 +285,35 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
                 // socket (hence socket is var, not const).
                 var socket = try client.getOrConnectSocket();
 
-                var writer_buf: [4096]u8 = undefined;
-                var writer = socket.writer(client.io, &writer_buf);
-                loop: while (true) {
-                    writer.interface.writeAll(data) catch |err| switch (writer.err.?) {
-                        error.ConnectionResetByPeer => {
+                // position in data that we've written to so far (or, put differently,
+                // positition in data that our next write starts at)
+                var pos: usize = 0;
+
+                loop: while (pos < data.len) {
+                    pos += posix.write(socket.socket.handle, data[pos..]) catch |err| switch (err) {
+                        error.WouldBlock => {
+                            const timeout: i32 = @intCast(std.Io.Timestamp.now(client.io, .awake).toMilliseconds() - absolute_timeout);
+                            if (timeout < 0) {
+                                return error.Timeout;
+                            }
+
+                            var fds = [1]posix.pollfd{.{ .fd = socket.socket.handle, .events = posix.POLL.OUT, .revents = 0 }};
+                            if (try posix.poll(&fds, timeout) == 0) {
+                                return error.Timeout;
+                            }
+
+                            const revents = fds[0].revents;
+                            if (revents & posix.POLL.OUT != posix.POLL.OUT) {
+                                // handle any other non-POLLOUT event as an error
+                                socket = try handleError(client, &retries);
+                            }
+
+                            // Either poll has told us we can write without blocking OR
+                            // poll told us there was a error, but retries > 0 and we managed
+                            // to reconnect. Either way, we're gonna try to write again.
+                            continue :loop;
+                        },
+                        error.BrokenPipe, error.ConnectionResetByPeer => {
                             socket = try handleError(client, &retries);
                             continue :loop;
                         },
@@ -283,17 +322,6 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
                             return err;
                         },
                     };
-                    writer.interface.flush() catch |err| switch (writer.err.?) {
-                        error.ConnectionResetByPeer => {
-                            socket = try handleError(client, &retries);
-                            continue :loop;
-                        },
-                        else => {
-                            client.close();
-                            return err;
-                        },
-                    };
-                    return;
                 }
             }
 
@@ -351,7 +379,10 @@ const Address = struct {
         _ = timeout; // TODO: check how to set the timeout on the socket in 0.16.
 
         if (self.address) |addr| {
-            return try addr.connect(self.io, .{ .mode = .stream, .protocol = .tcp });
+            const stream = try addr.connect(self.io, .{ .mode = .stream, .protocol = .tcp });
+
+            try makeStreamAsync(&stream);
+            return stream;
         }
 
         // If we don't have an address, then we were given a host:ip.
@@ -359,7 +390,16 @@ const Address = struct {
         // IPs, hence why we don't convert host:ip -> net.Address in init.
         const host = self.host.?;
         const host_name = try std.Io.net.HostName.init(host.name);
-        return try host_name.connect(self.io, self.host.?.port, .{ .mode = .stream, .protocol = .tcp });
+        const stream = try host_name.connect(self.io, self.host.?.port, .{ .mode = .stream, .protocol = .tcp });
+
+        try makeStreamAsync(&stream);
+        return stream;
+    }
+
+    fn makeStreamAsync(stream: *const net.Stream) !void {
+        const fd = stream.socket.handle;
+        const flags = try posix.fcntl(fd, posix.F.GETFL, 0);
+        _ = try posix.fcntl(fd, posix.F.SETFL, flags | @as(usize, 1 << @bitOffsetOf(posix.O, "NONBLOCK")));
     }
 };
 

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -220,40 +220,50 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
             pub fn read(ctx: *const Context, buf: []u8, _: usize) !?usize {
                 var client = ctx.client;
 
-                // const absolute_timeout = std.time.milliTimestamp() + ctx.timeout;
+                const absolute_timeout = std.Io.Clock.now(.awake, client.io).toMilliseconds() + ctx.timeout;
 
                 // on disconnect, the number of times that we'll try to reconnect and
                 // continue. This counts downwards to 0.
-                const retries = ctx.retries;
-
-                // _ = absolute_timeout;
-                _ = retries;
-
-                // TODO: understand how to integrate timeout and retries.
+                var retries = ctx.retries;
 
                 // If retries > 0 and we detect a disconnect, we'll attempt to reload the
                 // socket (hence socket is var, not const).
                 var socket = try client.getOrConnectSocket();
+                loop: while (true) {
+                    const res = socket.socket.receiveTimeout(
+                        client.io,
+                        buf,
+                        .{ .duration = .{ .raw = .fromMilliseconds(absolute_timeout), .clock = .awake } },
+                    ) catch |err| switch (err) {
+                        error.ConnectionResetByPeer => {
+                            socket = try handleError(client, &retries);
+                            continue :loop;
+                        },
+                        error.Timeout => {
+                            const timeout: i32 = @intCast(absolute_timeout - std.Io.Clock.now(.awake, client.io).toMilliseconds());
+                            if (timeout < 0) {
+                                return null;
+                            }
+                            continue :loop;
+                        },
+                        else => {
+                            std.debug.print("{any}\n", .{err});
+                            client.close();
+                            return err;
+                        },
+                    };
 
-                const res = try socket.socket.receive(client.io, buf);
-                std.debug.print("{s}\n", .{res.data});
-                return res.data.len;
+                    if (res.data.len != 0) return res.data.len;
+                }
             }
 
             // Called by our composed mqtt.Client
             pub fn write(ctx: *const Context, data: []const u8) !void {
                 var client = ctx.client;
 
-                // const absolute_timeout = std.Io.Timestamp.now(client.io, .awake).toMilliseconds() + ctx.timeout;
-
                 // on disconnect, the number of times that we'll try to reconnect and
                 // continue. This counts downwards to 0.
-                const retries = ctx.retries;
-
-                // _ = absolute_timeout;
-                _ = retries;
-
-                // TODO: understand how to integrate timeout and retries.
+                var retries = ctx.retries;
 
                 // If retries > 0 and we detect a disconnect, we'll attempt to reload the
                 // socket (hence socket is var, not const).
@@ -261,8 +271,31 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
 
                 var writer_buf: [4096]u8 = undefined;
                 var writer = socket.writer(client.io, &writer_buf);
-                try writer.interface.writeAll(data);
-                try writer.interface.flush();
+                loop: while (true) {
+                    writer.interface.writeAll(data) catch |err| switch (writer.err.?) {
+                        error.ConnectionResetByPeer => {
+                            socket = try handleError(client, &retries);
+                            continue :loop;
+                        },
+                        else => {
+                            std.debug.print("{any}\n", .{err});
+                            client.close();
+                            return err;
+                        },
+                    };
+                    writer.interface.flush() catch |err| switch (writer.err.?) {
+                        error.ConnectionResetByPeer => {
+                            socket = try handleError(client, &retries);
+                            continue :loop;
+                        },
+                        else => {
+                            std.debug.print("{any}\n", .{err});
+                            client.close();
+                            return err;
+                        },
+                    };
+                    return;
+                }
             }
 
             // Called by our composed mqtt.Client
@@ -270,7 +303,7 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
                 ctx.client.close();
             }
 
-            fn handleError(client: *Self, retries: *u16) !posix.socket_t {
+            fn handleError(client: *Self, retries: *u16) !net.Stream {
                 client.close();
                 const r = retries.*;
                 if (r == 0) {

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -188,7 +188,7 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
 
         fn getOrConnectSocket(self: *Self) !net.Stream {
             return self.socket orelse {
-                const socket = try self.address.connect(self.allocator, self.connect_timeout);
+                const socket = try self.address.connect(self.connect_timeout);
                 self.socket = socket;
                 return socket;
             };
@@ -292,7 +292,7 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
                 loop: while (pos < data.len) {
                     pos += posix.write(socket.socket.handle, data[pos..]) catch |err| switch (err) {
                         error.WouldBlock => {
-                            const timeout: i32 = @intCast(std.Io.Timestamp.now(client.io, .awake).toMilliseconds() - absolute_timeout);
+                            const timeout: i32 = @intCast(absolute_timeout - std.Io.Timestamp.now(client.io, .awake).toMilliseconds());
                             if (timeout < 0) {
                                 return error.Timeout;
                             }
@@ -374,9 +374,8 @@ const Address = struct {
         return .{ .io = io, .host = .{ .name = host, .port = port } };
     }
 
-    fn connect(self: *Address, allocator: ?Allocator, timeout: i32) !net.Stream {
-        _ = allocator;
-        _ = timeout; // TODO: check how to set the timeout on the socket in 0.16.
+    fn connect(self: *Address, timeout: i32) !net.Stream {
+        _ = timeout;
 
         if (self.address) |addr| {
             const stream = try addr.connect(self.io, .{ .mode = .stream, .protocol = .tcp });

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -220,7 +220,7 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
             pub fn read(ctx: *const Context, buf: []u8, _: usize) !?usize {
                 var client = ctx.client;
 
-                const absolute_timeout = std.Io.Clock.now(.awake, client.io).toMilliseconds() + ctx.timeout;
+                // const absolute_timeout = std.Io.Clock.now(.awake, client.io).toMilliseconds() + ctx.timeout;
 
                 // on disconnect, the number of times that we'll try to reconnect and
                 // continue. This counts downwards to 0.
@@ -238,13 +238,13 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
                             socket = try handleError(client, &retries);
                             continue :loop;
                         },
-                        error.Timeout => {
-                            const timeout: i32 = @intCast(absolute_timeout - std.Io.Clock.now(.awake, client.io).toMilliseconds());
-                            if (timeout < 0) {
-                                return null;
-                            }
-                            continue :loop;
-                        },
+                        // error.Timeout => {
+                        //     const timeout: i32 = @intCast(absolute_timeout - std.Io.Clock.now(.awake, client.io).toMilliseconds());
+                        //     if (timeout < 0) {
+                        //         return null;
+                        //     }
+                        //     continue :loop;
+                        // },
                         else => {
                             std.debug.print("{any}\n", .{err});
                             client.close();

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -229,12 +229,11 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
                 // If retries > 0 and we detect a disconnect, we'll attempt to reload the
                 // socket (hence socket is var, not const).
                 var socket = try client.getOrConnectSocket();
+                var reader_buf: [4096]u8 = undefined;
+                var socket_reader = socket.reader(client.io, &reader_buf);
+                var buf_writer = std.Io.Writer.fixed(buf);
                 loop: while (true) {
-                    const res = socket.socket.receiveTimeout(
-                        client.io,
-                        buf,
-                        .{ .duration = .{ .raw = .fromMilliseconds(absolute_timeout), .clock = .awake } },
-                    ) catch |err| switch (err) {
+                    const res = socket_reader.interface.stream(&buf_writer, .unlimited) catch |err| switch (socket_reader.err.?) {
                         error.ConnectionResetByPeer => {
                             socket = try handleError(client, &retries);
                             continue :loop;
@@ -252,8 +251,10 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
                             return err;
                         },
                     };
+                    try buf_writer.flush();
 
-                    if (res.data.len != 0) return res.data.len;
+                    if (res != 0) return res;
+                    continue :loop;
                 }
             }
 
@@ -278,7 +279,6 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
                             continue :loop;
                         },
                         else => {
-                            std.debug.print("{any}\n", .{err});
                             client.close();
                             return err;
                         },
@@ -289,7 +289,6 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
                             continue :loop;
                         },
                         else => {
-                            std.debug.print("{any}\n", .{err});
                             client.close();
                             return err;
                         },

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -356,6 +356,9 @@ const Address = struct {
     // initially null when we're given a host:port
     address: ?net.IpAddress = null,
 
+    _mutex: std.Io.Mutex = .init,
+    _cond: std.Io.Condition = .init,
+
     const Host = struct {
         port: u16,
         name: []const u8,
@@ -375,27 +378,50 @@ const Address = struct {
     }
 
     fn connect(self: *Address, timeout: i32) !net.Stream {
-        _ = timeout;
+        const io = self.io;
+        const deadline = @as(i64, @intCast(timeout)) * std.time.ns_per_ms;
+        const start = std.Io.Timestamp.now(io, .awake);
 
-        if (self.address) |addr| {
-            const stream = try addr.connect(self.io, .{ .mode = .stream, .protocol = .tcp });
+        try self._mutex.lock(io);
+        errdefer self._mutex.unlock(io);
 
-            try makeStreamAsync(&stream);
-            return stream;
+        const SelectResult = union(enum) { t: std.Io.Cancelable!void, c: std.Io.Cancelable!void };
+        var select_buf: [1]SelectResult = undefined;
+
+        var stream: ?std.Io.net.Stream = null;
+        while (true) {
+            if (self.address) |addr| {
+                stream = try addr.connect(self.io, .{ .mode = .stream, .protocol = .tcp });
+
+                try makeStreamAsync(&stream.?);
+            }
+
+            const host = self.host.?;
+            const host_name = try std.Io.net.HostName.init(host.name);
+            stream = try host_name.connect(self.io, self.host.?.port, .{ .mode = .stream, .protocol = .tcp });
+            try makeStreamAsync(&stream.?);
+
+            // Calculate remeaning timeout.
+            const now = std.Io.Timestamp.now(io, .awake);
+            const elapsed = start.durationTo(now).toNanoseconds();
+            if (elapsed >= deadline) {
+                return error.Timeout;
+            }
+
+            const remaining_ns = deadline - elapsed;
+
+            var select: std.Io.Select(SelectResult) = .init(io, &select_buf);
+            defer select.cancelDiscard();
+            try select.concurrent(.t, std.Io.sleep, .{ io, .fromNanoseconds(remaining_ns), .awake });
+            try select.concurrent(.c, std.Io.Condition.wait, .{ &self._cond, io, &self._mutex });
+
+            _ = try select.await();
+
+            return stream.?;
         }
-
-        // If we don't have an address, then we were given a host:ip.
-        // The address can change (DNS can be updated), and there can be multiple
-        // IPs, hence why we don't convert host:ip -> net.Address in init.
-        const host = self.host.?;
-        const host_name = try std.Io.net.HostName.init(host.name);
-        const stream = try host_name.connect(self.io, self.host.?.port, .{ .mode = .stream, .protocol = .tcp });
-
-        try makeStreamAsync(&stream);
-        return stream;
     }
 
-    fn makeStreamAsync(stream: *const net.Stream) !void {
+    fn makeStreamAsync(stream: *net.Stream) !void {
         const fd = stream.socket.handle;
         const flags = try posix.fcntl(fd, posix.F.GETFL, 0);
         _ = try posix.fcntl(fd, posix.F.SETFL, flags | @as(usize, 1 << @bitOffsetOf(posix.O, "NONBLOCK")));

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const mqttz = @import("mqtt.zig");
 const builtin = @import("builtin");
 
-const net = std.net;
+const net = std.Io.net;
 const posix = std.posix;
 const Allocator = std.mem.Allocator;
 
@@ -12,6 +12,7 @@ pub const Client311NoCheck = Client(.{ .mqtt_3_1_1 = false });
 
 pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
     return struct {
+        io: std.Io,
         // our posix client is a wrapper around the platform-agnostic mqttz.Mqtt client
         // we'll provide  read, write and close implementations (based around std.posix)
         // as well as other higher level functionality.
@@ -33,7 +34,7 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
 
         // set when connect is called, can be unset on error (indicating that we need
         // to reconnect)
-        socket: ?posix.socket_t,
+        socket: ?net.Stream,
 
         default_retries: u16,
         default_timeout: i32,
@@ -68,7 +69,7 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
 
         const Self = @This();
 
-        pub fn init(opts: Opts) !Self {
+        pub fn init(io: std.Io, opts: Opts) !Self {
             const allocator = opts.allocator;
 
             if (allocator == null and (opts.ip == null or opts.read_buf == null or opts.write_buf == null)) {
@@ -91,9 +92,10 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
             }
             errdefer if (write_buf_own) allocator.?.free(write_buf.?);
 
-            const address = try Address.init(opts.host, opts.ip, opts.port);
+            const address = try Address.init(io, opts.host, opts.ip, opts.port);
 
             return .{
+                .io = io,
                 .socket = null,
                 .address = address,
                 .allocator = allocator,
@@ -184,7 +186,7 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
             return self.mqtt.readPacket(&self.createContext(rw));
         }
 
-        fn getOrConnectSocket(self: *Self) !posix.socket_t {
+        fn getOrConnectSocket(self: *Self) !net.Stream {
             return self.socket orelse {
                 const socket = try self.address.connect(self.allocator, self.connect_timeout);
                 self.socket = socket;
@@ -194,7 +196,7 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
 
         fn close(self: *Self) void {
             if (self.socket) |socket| {
-                posix.close(socket);
+                socket.close(self.io);
                 self.socket = null;
             }
         }
@@ -218,110 +220,49 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
             pub fn read(ctx: *const Context, buf: []u8, _: usize) !?usize {
                 var client = ctx.client;
 
-                const absolute_timeout = std.time.milliTimestamp() + ctx.timeout;
+                // const absolute_timeout = std.time.milliTimestamp() + ctx.timeout;
 
                 // on disconnect, the number of times that we'll try to reconnect and
                 // continue. This counts downwards to 0.
-                var retries = ctx.retries;
+                const retries = ctx.retries;
+
+                // _ = absolute_timeout;
+                _ = retries;
+
+                // TODO: understand how to integrate timeout and retries.
 
                 // If retries > 0 and we detect a disconnect, we'll attempt to reload the
                 // socket (hence socket is var, not const).
                 var socket = try client.getOrConnectSocket();
-                loop: while (true) {
-                    const n = posix.read(socket, buf) catch |err| {
-                        switch (err) {
-                            error.BrokenPipe, error.ConnectionResetByPeer => {
-                                socket = try handleError(client, &retries);
-                                continue :loop;
-                            },
-                            error.WouldBlock => {
-                                const timeout: i32 = @intCast(absolute_timeout - std.time.milliTimestamp());
-                                if (timeout < 0) {
-                                    return null;
-                                }
 
-                                var fds = [1]posix.pollfd{.{ .fd = socket, .events = posix.POLL.IN, .revents = 0 }};
-                                if (try posix.poll(&fds, timeout) == 0) {
-                                    return null;
-                                }
-
-                                if (fds[0].revents & posix.POLL.IN != posix.POLL.IN) {
-                                    // handle any other non-POLLOUT event as an error
-                                    socket = try handleError(client, &retries);
-                                }
-
-                                // Either poll has told us we can read without blocking OR
-                                // poll told us there was a error, but retries > 0 and we managed
-                                // to reconnect. Either way, we're gonna try to read again.
-                                continue :loop;
-                            },
-                            else => {
-                                client.close();
-                                return err;
-                            },
-                        }
-                    };
-
-                    if (n != 0) {
-                        return n;
-                    }
-
-                    socket = try handleError(client, &retries);
-                }
+                const res = try socket.socket.receive(client.io, buf);
+                std.debug.print("{s}\n", .{res.data});
+                return res.data.len;
             }
 
             // Called by our composed mqtt.Client
             pub fn write(ctx: *const Context, data: []const u8) !void {
                 var client = ctx.client;
 
-                const absolute_timeout = std.time.milliTimestamp() + ctx.timeout;
+                // const absolute_timeout = std.Io.Timestamp.now(client.io, .awake).toMilliseconds() + ctx.timeout;
 
                 // on disconnect, the number of times that we'll try to reconnect and
                 // continue. This counts downwards to 0.
-                var retries = ctx.retries;
+                const retries = ctx.retries;
+
+                // _ = absolute_timeout;
+                _ = retries;
+
+                // TODO: understand how to integrate timeout and retries.
 
                 // If retries > 0 and we detect a disconnect, we'll attempt to reload the
                 // socket (hence socket is var, not const).
                 var socket = try client.getOrConnectSocket();
 
-                // position in data that we've written to so far (or, put differently,
-                // positition in data that our next write starts at)
-                var pos: usize = 0;
-
-                loop: while (pos < data.len) {
-                    pos += posix.write(socket, data[pos..]) catch |err| switch (err) {
-                        error.WouldBlock => {
-                            const timeout: i32 = @intCast(std.time.milliTimestamp() - absolute_timeout);
-                            if (timeout < 0) {
-                                return error.Timeout;
-                            }
-
-                            var fds = [1]posix.pollfd{.{ .fd = socket, .events = posix.POLL.OUT, .revents = 0 }};
-                            if (try posix.poll(&fds, timeout) == 0) {
-                                return error.Timeout;
-                            }
-
-                            const revents = fds[0].revents;
-                            if (revents & posix.POLL.OUT != posix.POLL.OUT) {
-                                // handle any other non-POLLOUT event as an error
-                                socket = try handleError(client, &retries);
-                            }
-
-                            // Either poll has told us we can write without blocking OR
-                            // poll told us there was a error, but retries > 0 and we managed
-                            // to reconnect. Either way, we're gonna try to write again.
-                            continue :loop;
-                        },
-                        error.BrokenPipe, error.ConnectionResetByPeer => {
-                            socket = try handleError(client, &retries);
-                            continue :loop;
-                        },
-                        else => {
-                            client.close();
-                            return err;
-                        },
-                    };
-                }
+                var writer_buf: [4096]u8 = undefined;
+                var writer = socket.writer(client.io, &writer_buf);
+                try writer.interface.writeAll(data);
+                try writer.interface.flush();
             }
 
             // Called by our composed mqtt.Client
@@ -347,76 +288,46 @@ pub fn Client(comptime protocol_version: mqttz.ProtocolVersion) type {
 // (a) we can handle the fact that host DNS can change and can have multiple IPs
 // (b) do a non-blocking connect (so we can timeout)
 const Address = struct {
+    io: std.Io,
+
     // null when we're given an ip:port.
     host: ?Host = null,
 
     // initially null when we're given a host:port
-    address: ?net.Address = null,
+    address: ?net.IpAddress = null,
 
     const Host = struct {
         port: u16,
         name: []const u8,
     };
 
-    fn init(optional_host: ?[]const u8, optional_ip: ?[]const u8, port: u16) !Address {
+    fn init(io: std.Io, optional_host: ?[]const u8, optional_ip: ?[]const u8, port: u16) !Address {
         if (optional_ip) |ip| {
             return .{
+                .io = io,
                 // setting a future resolved means, on connect/reconnect we won't try to
-                .address = try std.net.Address.parseIp(ip, port),
+                .address = try std.Io.net.IpAddress.parseIp4(ip, port),
             };
         }
 
         const host = optional_host orelse return error.HostOrIPRequired;
-        return .{ .host = .{ .name = host, .port = port } };
+        return .{ .io = io, .host = .{ .name = host, .port = port } };
     }
 
-    fn connect(self: *Address, allocator: ?Allocator, timeout: i32) !posix.socket_t {
+    fn connect(self: *Address, allocator: ?Allocator, timeout: i32) !net.Stream {
+        _ = allocator;
+        _ = timeout; // TODO: check how to set the timeout on the socket in 0.16.
+
         if (self.address) |addr| {
-            // we were given an ip:port, so the address is fixed
-            return connectTo(addr, timeout);
+            return try addr.connect(self.io, .{ .mode = .stream, .protocol = .tcp });
         }
 
         // If we don't have an address, then we were given a host:ip.
         // The address can change (DNS can be updated), and there can be multiple
         // IPs, hence why we don't convert host:ip -> net.Address in init.
         const host = self.host.?;
-        const list = try net.getAddressList(allocator.?, host.name, host.port);
-        defer list.deinit();
-
-        if (list.addrs.len == 0) {
-            return error.UnknownHostName;
-        }
-
-        for (list.addrs) |addr| {
-            return connectTo(addr, timeout) catch continue;
-        }
-
-        return posix.ConnectError.ConnectionRefused;
-    }
-
-    fn connectTo(addr: net.Address, timeout: i32) !posix.socket_t {
-        const sock_flags = posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC;
-        const socket = try posix.socket(addr.any.family, sock_flags, posix.IPPROTO.TCP);
-        errdefer posix.close(socket);
-
-        posix.connect(socket, &addr.any, addr.getOsSockLen()) catch |err| switch (err) {
-            error.WouldBlock => {
-                var fds = [1]posix.pollfd{.{ .fd = socket, .events = posix.POLL.OUT, .revents = 0 }};
-                if (try posix.poll(&fds, timeout) == 0) {
-                    return error.Timeout;
-                }
-
-                if (fds[0].revents & posix.POLL.OUT != posix.POLL.OUT) {
-                    return error.ConnectionRefused;
-                }
-
-                // if this returns void, then we've successfully connected
-                try posix.getsockoptError(socket);
-            },
-            else => return err,
-        };
-
-        return socket;
+        const host_name = try std.Io.net.HostName.init(host.name);
+        return try host_name.connect(self.io, self.host.?.port, .{ .mode = .stream, .protocol = .tcp });
     }
 };
 

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -356,9 +356,6 @@ const Address = struct {
     // initially null when we're given a host:port
     address: ?net.IpAddress = null,
 
-    _mutex: std.Io.Mutex = .init,
-    _cond: std.Io.Condition = .init,
-
     const Host = struct {
         port: u16,
         name: []const u8,
@@ -368,7 +365,6 @@ const Address = struct {
         if (optional_ip) |ip| {
             return .{
                 .io = io,
-                // setting a future resolved means, on connect/reconnect we won't try to
                 .address = try std.Io.net.IpAddress.parseIp4(ip, port),
             };
         }
@@ -378,47 +374,20 @@ const Address = struct {
     }
 
     fn connect(self: *Address, timeout: i32) !net.Stream {
-        const io = self.io;
-        const deadline = @as(i64, @intCast(timeout)) * std.time.ns_per_ms;
-        const start = std.Io.Timestamp.now(io, .awake);
+        _ = timeout; // TODO: 0.16's std.Io.net.{IpAddress,HostName}.connect don't expose a timeout
 
-        try self._mutex.lock(io);
-        errdefer self._mutex.unlock(io);
-
-        const SelectResult = union(enum) { t: std.Io.Cancelable!void, c: std.Io.Cancelable!void };
-        var select_buf: [1]SelectResult = undefined;
-
-        var stream: ?std.Io.net.Stream = null;
-        while (true) {
-            if (self.address) |addr| {
-                stream = try addr.connect(self.io, .{ .mode = .stream, .protocol = .tcp });
-
-                try makeStreamAsync(&stream.?);
-            }
-
-            const host = self.host.?;
-            const host_name = try std.Io.net.HostName.init(host.name);
-            stream = try host_name.connect(self.io, self.host.?.port, .{ .mode = .stream, .protocol = .tcp });
-            try makeStreamAsync(&stream.?);
-
-            // Calculate remeaning timeout.
-            const now = std.Io.Timestamp.now(io, .awake);
-            const elapsed = start.durationTo(now).toNanoseconds();
-            if (elapsed >= deadline) {
-                return error.Timeout;
-            }
-
-            const remaining_ns = deadline - elapsed;
-
-            var select: std.Io.Select(SelectResult) = .init(io, &select_buf);
-            defer select.cancelDiscard();
-            try select.concurrent(.t, std.Io.sleep, .{ io, .fromNanoseconds(remaining_ns), .awake });
-            try select.concurrent(.c, std.Io.Condition.wait, .{ &self._cond, io, &self._mutex });
-
-            _ = try select.await();
-
-            return stream.?;
+        if (self.address) |addr| {
+            var stream = try addr.connect(self.io, .{ .mode = .stream, .protocol = .tcp });
+            try makeStreamAsync(&stream);
+            return stream;
         }
+
+        // host:port — HostName.connect handles resolution and iterating addrs internally
+        const host = self.host.?;
+        const host_name = try std.Io.net.HostName.init(host.name);
+        var stream = try host_name.connect(self.io, host.port, .{ .mode = .stream, .protocol = .tcp });
+        try makeStreamAsync(&stream);
+        return stream;
     }
 
     fn makeStreamAsync(stream: *net.Stream) !void {

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -406,9 +406,10 @@ const Address = struct {
 const t = std.testing;
 
 test {
+    const io = t.io;
     const addr = try net.IpAddress.parseIp4("127.0.0.1", 6588);
-    var serv = try addr.listen(t.io, .{ .reuse_address = true, .mode = .stream, .protocol = .tcp });
-    const thread = try std.Thread.spawn(.{}, TestServer.run, .{&serv});
+    var serv = try addr.listen(io, .{ .reuse_address = true });
+    const thread = try std.Thread.spawn(.{}, TestServer.run, .{ io, &serv });
     thread.detach();
 }
 
@@ -511,12 +512,12 @@ test "Client: read invalid response" {
 const TestServer = struct {
     // runs in a thread, but our TestServer itself is single threaded as, currently,
     // each test only needs 1 connection to the server at a time.
-    fn run(server: *net.Server) !void {
+    fn run(io: std.Io, server: *net.Server) !void {
         var state = State{};
 
         while (true) {
-            const socket = try server.accept(t.io);
-            defer socket.close(t.io);
+            const socket = try server.accept(io);
+            defer socket.close(io);
 
             var conn = TestConn{
                 .buf = undefined,

--- a/src/posix_interface.zig
+++ b/src/posix_interface.zig
@@ -7,6 +7,7 @@ pub const system = posix.system;
 const native_os = builtin.os.tag;
 
 pub const fd_t = posix.fd_t;
+pub const socket_t = posix.socket_t;
 pub const SOCK = posix.SOCK;
 pub const pollfd = system.pollfd;
 pub const POLL = posix.POLL;

--- a/src/posix_interface.zig
+++ b/src/posix_interface.zig
@@ -1,0 +1,169 @@
+const builtin = @import("builtin");
+const std = @import("std");
+
+const posix = std.posix;
+const windows = std.os.windows;
+pub const system = posix.system;
+const native_os = builtin.os.tag;
+
+pub const fd_t = posix.fd_t;
+pub const SOCK = posix.SOCK;
+pub const pollfd = system.pollfd;
+pub const POLL = posix.POLL;
+pub const IPPROTO = posix.IPPROTO;
+pub const F = posix.F;
+pub const O = posix.O;
+
+pub const ReadError = error{
+    InputOutput,
+    SystemResources,
+    IsDir,
+    OperationAborted,
+    BrokenPipe,
+    ConnectionResetByPeer,
+    ConnectionTimedOut,
+    NotOpenForReading,
+    SocketNotConnected,
+
+    /// This error occurs when no global event loop is configured,
+    /// and reading from the file descriptor would block.
+    WouldBlock,
+
+    /// reading a timerfd with CANCEL_ON_SET will lead to this error
+    /// when the clock goes through a discontinuous change
+    Canceled,
+
+    /// In WASI, this error occurs when the file descriptor does
+    /// not hold the required rights to read from it.
+    AccessDenied,
+
+    /// This error occurs in Linux if the process to be read from
+    /// no longer exists.
+    ProcessNotFound,
+
+    /// Unable to read file due to lock.
+    LockViolation,
+} || posix.UnexpectedError;
+
+pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
+    if (buf.len == 0) return 0;
+    if (native_os == .windows) {
+        return windows.ReadFile(fd, buf, null);
+    }
+
+    // Prevents EINVAL.
+    const max_count = switch (native_os) {
+        .linux => 0x7ffff000,
+        .macos, .ios, .watchos, .tvos, .visionos => std.math.maxInt(i32),
+        else => std.math.maxInt(isize),
+    };
+    while (true) {
+        const rc = system.read(fd, buf.ptr, @min(buf.len, max_count));
+        switch (posix.errno(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .INVAL => unreachable,
+            .FAULT => unreachable,
+            .SRCH => return error.ProcessNotFound,
+            .AGAIN => return error.WouldBlock,
+            .CANCELED => return error.Canceled,
+            .BADF => return error.NotOpenForReading, // Can be a race condition.
+            .IO => return error.InputOutput,
+            .ISDIR => return error.IsDir,
+            .NOBUFS => return error.SystemResources,
+            .NOMEM => return error.SystemResources,
+            .NOTCONN => return error.SocketNotConnected,
+            .CONNRESET => return error.ConnectionResetByPeer,
+            .TIMEDOUT => return error.ConnectionTimedOut,
+            else => return error.Unexpected,
+        }
+    }
+}
+
+pub fn write(fd: fd_t, bytes: []const u8) !usize {
+    if (bytes.len == 0) return 0;
+    if (native_os == .windows) {
+        return windows.WriteFile(fd, bytes, null);
+    }
+
+    const max_count = switch (native_os) {
+        .linux => 0x7ffff000,
+        .macos, .ios, .watchos, .tvos, .visionos => std.math.maxInt(i32),
+        else => std.math.maxInt(isize),
+    };
+    while (true) {
+        const rc = system.write(fd, bytes.ptr, @min(bytes.len, max_count));
+        switch (posix.errno(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .INVAL => return error.InvalidArgument,
+            .FAULT => unreachable,
+            .SRCH => return error.ProcessNotFound,
+            .AGAIN => return error.WouldBlock,
+            .BADF => return error.NotOpenForWriting, // can be a race condition.
+            .DESTADDRREQ => unreachable, // `connect` was never called.
+            .DQUOT => return error.DiskQuota,
+            .FBIG => return error.FileTooBig,
+            .IO => return error.InputOutput,
+            .NOSPC => return error.NoSpaceLeft,
+            .ACCES => return error.AccessDenied,
+            .PERM => return error.PermissionDenied,
+            .PIPE => return error.BrokenPipe,
+            .CONNRESET => return error.ConnectionResetByPeer,
+            .BUSY => return error.DeviceBusy,
+            .NXIO => return error.NoDevice,
+            .MSGSIZE => return error.MessageTooBig,
+            else => return error.Unexpected,
+        }
+    }
+}
+
+pub const PollError = posix.PollError;
+
+pub fn poll(fds: []pollfd, timeout: i32) PollError!usize {
+    if (native_os == .windows) {
+        switch (windows.poll(fds.ptr, @intCast(fds.len), timeout)) {
+            windows.ws2_32.SOCKET_ERROR => switch (windows.ws2_32.WSAGetLastError()) {
+                .WSANOTINITIALISED => unreachable,
+                .WSAENETDOWN => return error.NetworkSubsystemFailed,
+                .WSAENOBUFS => return error.SystemResources,
+                // TODO: handle more errors
+                else => |err| return windows.unexpectedWSAError(err),
+            },
+            else => |rc| return @intCast(rc),
+        }
+    }
+    while (true) {
+        const fds_count = std.math.cast(posix.nfds_t, fds.len) orelse return error.SystemResources;
+        const rc = system.poll(fds.ptr, fds_count, timeout);
+        switch (posix.errno(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .FAULT => unreachable,
+            .INTR => continue,
+            .INVAL => unreachable,
+            .NOMEM => return error.SystemResources,
+            else => |err| return posix.unexpectedErrno(err),
+        }
+    }
+    unreachable;
+}
+
+pub fn fcntl(fd: fd_t, cmd: i32, arg: usize) !usize {
+    while (true) {
+        const rc = posix.system.fcntl(fd, cmd, arg);
+        switch (posix.errno(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .AGAIN, .ACCES => return error.Locked,
+            .BADF => unreachable,
+            .BUSY => return error.FileBusy,
+            .INVAL => unreachable, // invalid parameters
+            .PERM => return error.PermissionDenied,
+            .MFILE => return error.ProcessFdQuotaExceeded,
+            .NOTDIR => unreachable, // invalid parameter
+            .DEADLK => return error.DeadLock,
+            .NOLCK => return error.LockedRegionLimitExceeded,
+            else => return error.Unexpected,
+        }
+    }
+}

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -1,3 +1,17 @@
+// This is for the Zig 0.16.
+
+// See https://gist.github.com/karlseguin/c6bea5b35e4e8d26af6f81c22cb5d76b/eb15512d6ae49663fa9df6c7a9725b20dab43edd
+// for a version that workson Zig 0.15.2.
+
+// See https://gist.github.com/karlseguin/c6bea5b35e4e8d26af6f81c22cb5d76b/1f317ebc9cd09bc50fd5591d09c34255e15d1d85
+// for a version that workson Zig 0.14.1.
+
+// in your build.zig, you can specify a custom test runner:
+// const tests = b.addTest(.{
+//    .root_module = $MODULE_BEING_TESTED,
+//    .test_runner = .{ .path = b.path("test_runner.zig"), .mode = .simple },
+// });
+
 // in your build.zig, you can specify a custom test runner:
 // const tests = b.addTest(.{
 //    .root_module = $MODULE_BEING_TESTED,
@@ -5,6 +19,7 @@
 // });
 
 const std = @import("std");
+const Io = std.Io;
 const builtin = @import("builtin");
 
 const Allocator = std.mem.Allocator;
@@ -20,10 +35,17 @@ pub fn main(init: std.process.Init) !void {
 
     const allocator = fba.allocator();
 
-    const env = Env.init(allocator, init.minimal);
-    defer env.deinit(allocator);
+    const env = Env.init(init.environ_map);
 
-    var slowest = SlowTracker.init(init.io, allocator, 5);
+    std.testing.io_instance = .init(init.gpa, .{
+        .argv0 = .init(init.minimal.args),
+        .environ = init.minimal.environ,
+    });
+    defer std.testing.io_instance.deinit();
+
+    const io = std.testing.io;
+
+    var slowest = SlowTracker.init(allocator, io, 5);
     defer slowest.deinit();
 
     var pass: usize = 0;
@@ -48,7 +70,7 @@ pub fn main(init: std.process.Init) !void {
         }
 
         var status = Status.pass;
-        slowest.startTiming();
+        slowest.startTiming(io);
 
         const is_unnamed_test = isUnnamed(t);
         if (env.filter) |f| {
@@ -74,7 +96,7 @@ pub fn main(init: std.process.Init) !void {
         const result = t.func();
         current_test = null;
 
-        const ns_taken = slowest.endTiming(friendly_name);
+        const ns_taken = slowest.endTiming(io, friendly_name);
 
         if (std.testing.allocator_instance.deinit() == .leak) {
             leak += 1;
@@ -92,7 +114,9 @@ pub fn main(init: std.process.Init) !void {
                 status = .fail;
                 fail += 1;
                 Printer.status(.fail, "\n{s}\n\"{s}\" - {s}\n{s}\n", .{ BORDER, friendly_name, @errorName(err), BORDER });
-                std.debug.dumpCurrentStackTrace(.{});
+                if (@errorReturnTrace()) |trace| {
+                    std.debug.dumpErrorReturnTrace(trace);
+                }
                 if (env.fail_first) {
                     break;
                 }
@@ -155,28 +179,27 @@ const Status = enum {
 };
 
 const SlowTracker = struct {
-    const SlowestQueue = std.PriorityDequeue(TestInfo, void, compareTiming);
-    allocator: std.mem.Allocator,
-    io: std.Io,
     max: usize,
     slowest: SlowestQueue,
-    timer: std.Io.Timestamp,
+    start: Io.Timestamp,
+    allocator: Allocator,
 
-    fn init(io: std.Io, allocator: Allocator, count: u32) SlowTracker {
-        const timer = std.Io.Timestamp.now(io, .awake);
-        var slowest = SlowestQueue.empty;
+    const SlowestQueue = std.PriorityDequeue(TestInfo, void, compareTiming);
+
+    fn init(allocator: Allocator, io: Io, count: u32) SlowTracker {
+        const timestamp = Io.Clock.awake.now(io);
+        var slowest: SlowestQueue = .empty;
         slowest.ensureTotalCapacity(allocator, count) catch @panic("OOM");
         return .{
-            .allocator = allocator,
-            .io = io,
             .max = count,
-            .timer = timer,
+            .start = timestamp,
             .slowest = slowest,
+            .allocator = allocator,
         };
     }
 
     const TestInfo = struct {
-        ns: i96,
+        ns: u64,
         name: []const u8,
     };
 
@@ -184,12 +207,15 @@ const SlowTracker = struct {
         self.slowest.deinit(self.allocator);
     }
 
-    fn startTiming(self: *SlowTracker) void {
-        self.timer = std.Io.Timestamp.now(self.io, .awake);
+    fn startTiming(self: *SlowTracker, io: Io) void {
+        self.start = Io.Clock.awake.now(io);
     }
 
-    fn endTiming(self: *SlowTracker, test_name: []const u8) i96 {
-        const ns = std.Io.Timestamp.now(self.io, .awake).toNanoseconds() - self.timer.toNanoseconds();
+    fn endTiming(self: *SlowTracker, io: Io, test_name: []const u8) u64 {
+        const timestamp = Io.Clock.awake.now(io);
+        const start = self.start;
+        self.start = timestamp;
+        const ns: u64 = @intCast(start.durationTo(timestamp).toNanoseconds());
 
         var slowest = &self.slowest;
 
@@ -233,40 +259,24 @@ const SlowTracker = struct {
 };
 
 const Env = struct {
-    env: std.process.Init.Minimal,
     verbose: bool,
     fail_first: bool,
     filter: ?[]const u8,
 
-    fn init(allocator: Allocator, env: std.process.Init.Minimal) Env {
+    fn init(map: *const std.process.Environ.Map) Env {
         return .{
-            .env = env,
-            .verbose = readEnvBool(allocator, env, "TEST_VERBOSE", true),
-            .fail_first = readEnvBool(allocator, env, "TEST_FAIL_FIRST", false),
-            .filter = readEnv(allocator, env, "TEST_FILTER"),
+            .verbose = readEnvBool(map, "TEST_VERBOSE", true),
+            .fail_first = readEnvBool(map, "TEST_FAIL_FIRST", false),
+            .filter = readEnv(map, "TEST_FILTER"),
         };
     }
 
-    fn deinit(self: Env, allocator: Allocator) void {
-        if (self.filter) |f| {
-            allocator.free(f);
-        }
+    fn readEnv(map: *const std.process.Environ.Map, key: []const u8) ?[]const u8 {
+        return map.get(key);
     }
 
-    fn readEnv(allocator: Allocator, env: std.process.Init.Minimal, key: []const u8) ?[]const u8 {
-        const v = env.environ.getAlloc(allocator, key) catch |err| {
-            if (err == error.EnvironmentVariableNotFound) {
-                return null;
-            }
-            std.log.warn("failed to get env var {s} due to err {}", .{ key, err });
-            return null;
-        };
-        return v;
-    }
-
-    fn readEnvBool(allocator: Allocator, env: std.process.Init.Minimal, key: []const u8, deflt: bool) bool {
-        const value = readEnv(allocator, env, key) orelse return deflt;
-        defer allocator.free(value);
+    fn readEnvBool(map: *const std.process.Environ.Map, key: []const u8, deflt: bool) bool {
+        const value = readEnv(map, key) orelse return deflt;
         return std.ascii.eqlIgnoreCase(value, "true");
     }
 };

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -14,16 +14,16 @@ const BORDER = "=" ** 80;
 // use in custom panic handler
 var current_test: ?[]const u8 = null;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var mem: [8192]u8 = undefined;
     var fba = std.heap.FixedBufferAllocator.init(&mem);
 
     const allocator = fba.allocator();
 
-    const env = Env.init(allocator);
+    const env = Env.init(allocator, init.minimal);
     defer env.deinit(allocator);
 
-    var slowest = SlowTracker.init(allocator, 5);
+    var slowest = SlowTracker.init(init.io, allocator, 5);
     defer slowest.deinit();
 
     var pass: usize = 0;
@@ -92,9 +92,7 @@ pub fn main() !void {
                 status = .fail;
                 fail += 1;
                 Printer.status(.fail, "\n{s}\n\"{s}\" - {s}\n{s}\n", .{ BORDER, friendly_name, @errorName(err), BORDER });
-                if (@errorReturnTrace()) |trace| {
-                    std.debug.dumpStackTrace(trace.*);
-                }
+                std.debug.dumpCurrentStackTrace(.{});
                 if (env.fail_first) {
                     break;
                 }
@@ -130,7 +128,7 @@ pub fn main() !void {
     Printer.fmt("\n", .{});
     try slowest.display();
     Printer.fmt("\n", .{});
-    std.posix.exit(if (fail == 0) 0 else 1);
+    std.process.exit(if (fail == 0) 0 else 1);
 }
 
 const Printer = struct {
@@ -158,15 +156,19 @@ const Status = enum {
 
 const SlowTracker = struct {
     const SlowestQueue = std.PriorityDequeue(TestInfo, void, compareTiming);
+    allocator: std.mem.Allocator,
+    io: std.Io,
     max: usize,
     slowest: SlowestQueue,
-    timer: std.time.Timer,
+    timer: std.Io.Timestamp,
 
-    fn init(allocator: Allocator, count: u32) SlowTracker {
-        const timer = std.time.Timer.start() catch @panic("failed to start timer");
-        var slowest = SlowestQueue.init(allocator, {});
-        slowest.ensureTotalCapacity(count) catch @panic("OOM");
+    fn init(io: std.Io, allocator: Allocator, count: u32) SlowTracker {
+        const timer = std.Io.Timestamp.now(io, .awake);
+        var slowest = SlowestQueue.empty;
+        slowest.ensureTotalCapacity(allocator, count) catch @panic("OOM");
         return .{
+            .allocator = allocator,
+            .io = io,
             .max = count,
             .timer = timer,
             .slowest = slowest,
@@ -174,28 +176,27 @@ const SlowTracker = struct {
     }
 
     const TestInfo = struct {
-        ns: u64,
+        ns: i96,
         name: []const u8,
     };
 
-    fn deinit(self: SlowTracker) void {
-        self.slowest.deinit();
+    fn deinit(self: *SlowTracker) void {
+        self.slowest.deinit(self.allocator);
     }
 
     fn startTiming(self: *SlowTracker) void {
-        self.timer.reset();
+        self.timer = std.Io.Timestamp.now(self.io, .awake);
     }
 
-    fn endTiming(self: *SlowTracker, test_name: []const u8) u64 {
-        var timer = self.timer;
-        const ns = timer.lap();
+    fn endTiming(self: *SlowTracker, test_name: []const u8) i96 {
+        const ns = std.Io.Timestamp.now(self.io, .awake).toNanoseconds() - self.timer.toNanoseconds();
 
         var slowest = &self.slowest;
 
         if (slowest.count() < self.max) {
             // Capacity is fixed to the # of slow tests we want to track
             // If we've tracked fewer tests than this capacity, than always add
-            slowest.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+            slowest.push(self.allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
             return ns;
         }
 
@@ -210,8 +211,8 @@ const SlowTracker = struct {
         }
 
         // the previous fastest of our slow tests, has been pushed off.
-        _ = slowest.removeMin();
-        slowest.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+        _ = slowest.popMin();
+        slowest.push(self.allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
         return ns;
     }
 
@@ -219,7 +220,7 @@ const SlowTracker = struct {
         var slowest = self.slowest;
         const count = slowest.count();
         Printer.fmt("Slowest {d} test{s}: \n", .{ count, if (count != 1) "s" else "" });
-        while (slowest.removeMinOrNull()) |info| {
+        while (slowest.popMin()) |info| {
             const ms = @as(f64, @floatFromInt(info.ns)) / 1_000_000.0;
             Printer.fmt("  {d:.2}ms\t{s}\n", .{ ms, info.name });
         }
@@ -232,15 +233,17 @@ const SlowTracker = struct {
 };
 
 const Env = struct {
+    env: std.process.Init.Minimal,
     verbose: bool,
     fail_first: bool,
     filter: ?[]const u8,
 
-    fn init(allocator: Allocator) Env {
+    fn init(allocator: Allocator, env: std.process.Init.Minimal) Env {
         return .{
-            .verbose = readEnvBool(allocator, "TEST_VERBOSE", true),
-            .fail_first = readEnvBool(allocator, "TEST_FAIL_FIRST", false),
-            .filter = readEnv(allocator, "TEST_FILTER"),
+            .env = env,
+            .verbose = readEnvBool(allocator, env, "TEST_VERBOSE", true),
+            .fail_first = readEnvBool(allocator, env, "TEST_FAIL_FIRST", false),
+            .filter = readEnv(allocator, env, "TEST_FILTER"),
         };
     }
 
@@ -250,8 +253,8 @@ const Env = struct {
         }
     }
 
-    fn readEnv(allocator: Allocator, key: []const u8) ?[]const u8 {
-        const v = std.process.getEnvVarOwned(allocator, key) catch |err| {
+    fn readEnv(allocator: Allocator, env: std.process.Init.Minimal, key: []const u8) ?[]const u8 {
+        const v = env.environ.getAlloc(allocator, key) catch |err| {
             if (err == error.EnvironmentVariableNotFound) {
                 return null;
             }
@@ -261,8 +264,8 @@ const Env = struct {
         return v;
     }
 
-    fn readEnvBool(allocator: Allocator, key: []const u8, deflt: bool) bool {
-        const value = readEnv(allocator, key) orelse return deflt;
+    fn readEnvBool(allocator: Allocator, env: std.process.Init.Minimal, key: []const u8, deflt: bool) bool {
+        const value = readEnv(allocator, env, key) orelse return deflt;
         defer allocator.free(value);
         return std.ascii.eqlIgnoreCase(value, "true");
     }


### PR DESCRIPTION
Hello!

First of all, nice library, I really like it!
I wanted to use this with Zig 0.16, so I started a migration to the new std lib apis.
The posix client is now working with the new `std.Io.net.Stream.Reader` and `std.Io.net.Stream.Writer` interfaces.
I still need to fix posix tests and the `low_level` example, but I would like to have a first feedback from you.

This migration brings a couple of challenges:
  - proper usage of the `std.Io` interface to do async/concurrent stuff.
  - timeout handling.

I'm more concerned about the last one, I didn't find a way to successfully handle timeouts as you did in 0.15.2.
After looking at the stantard library for a couple of hours and reading the open issues, I've came accross [this issue](https://codeberg.org/ziglang/zig/issues/31098) which suggests that timeout should be managed by the I/O interface (we should wait for this to be implemented).

Let me know what you think of this, I'll be more than happy to work on this and make it better if that's ok with you!